### PR TITLE
fix: rename to @exodus/walletconnect-core-v1

### DIFF
--- a/packages/clients/core/package.json
+++ b/packages/clients/core/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@exodus/walletconnect-core",
-  "version": "1.7.0-exodus.2",
+  "name": "@exodus/walletconnect-core-v1",
+  "version": "1.7.0-exodus.3",
   "description": "Core Library for WalletConnect",
   "scripts": {
     "clean": "rm -rf dist",


### PR DESCRIPTION
Conficts with v2's `@exodus/walletconnect-core` package.