### PR TITLE
fix: don't bundle exodus/crypto/*

### DIFF
--- a/packages/utils/rollup.config.js
+++ b/packages/utils/rollup.config.js
@@ -1,4 +1,13 @@
 import { name, dependencies } from "./package.json";
 import createConfig from "../../rollup.config";
 
-export default createConfig(name, Object.keys(dependencies));
+const packageDependencies = [
+  ...Object.keys(dependencies),
+  "@exodus/crypto/curve25519",
+  "@exodus/crypto/chacha",
+  "@exodus/crypto/hash",
+  "@exodus/crypto/hmac",
+  "@exodus/crypto/randomBytes",
+]
+
+export default createConfig(name, packageDependencies);


### PR DESCRIPTION
We don't want to bundle those and rollup doesn't catch it