### PR TITLE
feat: enable Verify API resolution (RN-compatible plain fetch)

### DIFF
--- a/packages/core/src/constants/verify.ts
+++ b/packages/core/src/constants/verify.ts
@@ -1,1 +1,9 @@
 export const VERIFY_CONTEXT = "verify-api";
+
+export const VERIFY_SERVER = "https://verify.walletconnect.com";
+
+export const VERIFY_FALLBACK_SERVER = "https://verify.walletconnect.org";
+
+export const TRUSTED_VERIFY_URLS = [VERIFY_SERVER, VERIFY_FALLBACK_SERVER];
+
+export const VERIFY_FETCH_TIMEOUT_MS = 2000;

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -1,7 +1,13 @@
 import { generateChildLogger, getLoggerContext, Logger } from "@exodus/walletconnect-logger";
 import { IVerify } from "@exodus/walletconnect-types";
 
-import { VERIFY_CONTEXT } from "../constants";
+import {
+  TRUSTED_VERIFY_URLS,
+  VERIFY_CONTEXT,
+  VERIFY_FALLBACK_SERVER,
+  VERIFY_FETCH_TIMEOUT_MS,
+  VERIFY_SERVER,
+} from "../constants";
 
 export class Verify extends IVerify {
   public name = VERIFY_CONTEXT;
@@ -13,15 +19,55 @@ export class Verify extends IVerify {
 
   public init: IVerify["init"] = async (_params) => {};
 
-  public register: IVerify["register"] = async (_params) => {
-    throw new Error("verify not supported in exodus fork yet");
-  };
+  // dApp-side iframe registration is not used in a wallet build (no DOM); intentional no-op.
+  public register: IVerify["register"] = async (_params) => {};
 
-  public resolve: IVerify["resolve"] = async (_params) => {
-    throw new Error("verify not supported in exodus fork yet");
+  public resolve: IVerify["resolve"] = async (params) => {
+    const { attestationId } = params;
+    if (!attestationId) return undefined;
+    const verifyUrl = this.getVerifyUrl(params?.verifyUrl);
+    try {
+      return await this.fetchAttestation(attestationId, verifyUrl);
+    } catch (error) {
+      this.logger.info(`failed to resolve attestation: ${attestationId} from url: ${verifyUrl}`);
+      this.logger.info(error);
+      if (verifyUrl === VERIFY_FALLBACK_SERVER) return undefined;
+      try {
+        return await this.fetchAttestation(attestationId, VERIFY_FALLBACK_SERVER);
+      } catch (fallbackError) {
+        this.logger.info(`fallback attestation fetch also failed`);
+        this.logger.info(fallbackError);
+        return undefined;
+      }
+    }
   };
 
   get context(): string {
     return getLoggerContext(this.logger);
   }
+
+  private fetchAttestation = async (attestationId: string, url: string) => {
+    this.logger.debug(`resolving attestation: ${attestationId} from url: ${url}`);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), VERIFY_FETCH_TIMEOUT_MS);
+    try {
+      const result = await fetch(`${url}/attestation/${attestationId}`, {
+        signal: controller.signal,
+      });
+      return result.status === 200 ? await result.json() : undefined;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  };
+
+  private getVerifyUrl = (verifyUrl?: string) => {
+    let url = verifyUrl || VERIFY_SERVER;
+    if (!TRUSTED_VERIFY_URLS.includes(url)) {
+      this.logger.info(
+        `verify url: ${url}, not included in trusted list, assigning default: ${VERIFY_SERVER}`,
+      );
+      url = VERIFY_SERVER;
+    }
+    return url;
+  };
 }

--- a/packages/core/test/verify.spec.ts
+++ b/packages/core/test/verify.spec.ts
@@ -1,0 +1,136 @@
+import { expect, describe, it, beforeEach, afterEach, vi } from "vitest";
+import { getDefaultLoggerOptions, pino } from "@exodus/walletconnect-logger";
+
+import { Verify } from "../src/controllers/verify";
+import { VERIFY_FALLBACK_SERVER, VERIFY_SERVER } from "../src/constants";
+
+const TEST_PROJECT_ID = "test-project-id";
+const TEST_ATTESTATION_ID = "test-attestation-id";
+
+describe("Verify", () => {
+  const logger = pino(getDefaultLoggerOptions({ level: "fatal" }));
+  let verify: Verify;
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    verify = new Verify(TEST_PROJECT_ID, logger);
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe("init", () => {
+    it("is a no-op (wallet build has no DOM iframe)", async () => {
+      await expect(verify.init()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("register", () => {
+    it("is a no-op (dApp-side registration is browser-only and unused in wallet)", async () => {
+      await expect(
+        verify.register({ attestationId: TEST_ATTESTATION_ID }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("resolve", () => {
+    it("returns undefined when attestationId is empty", async () => {
+      const fetchSpy = vi.fn();
+      global.fetch = fetchSpy as any;
+      const result = await verify.resolve({ attestationId: "" });
+      expect(result).toBeUndefined();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("hits VERIFY_SERVER and returns parsed JSON on 200", async () => {
+      const expected = { origin: "https://uniswap.org", isScam: false };
+      global.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        json: async () => expected,
+      }) as any;
+      const result = await verify.resolve({ attestationId: TEST_ATTESTATION_ID });
+      expect(result).toEqual(expected);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${VERIFY_SERVER}/attestation/${TEST_ATTESTATION_ID}`,
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it("returns undefined on non-200 response", async () => {
+      global.fetch = vi.fn().mockResolvedValue({ status: 404, json: async () => undefined }) as any;
+      const result = await verify.resolve({ attestationId: TEST_ATTESTATION_ID });
+      expect(result).toBeUndefined();
+    });
+
+    it("falls back to VERIFY_FALLBACK_SERVER when primary URL throws", async () => {
+      const expected = { origin: "https://fallback.example" };
+      global.fetch = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("primary down"))
+        .mockResolvedValueOnce({ status: 200, json: async () => expected }) as any;
+      const result = await verify.resolve({ attestationId: TEST_ATTESTATION_ID });
+      expect(result).toEqual(expected);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        `${VERIFY_FALLBACK_SERVER}/attestation/${TEST_ATTESTATION_ID}`,
+        expect.anything(),
+      );
+    });
+
+    it("returns undefined when both primary and fallback throw", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("net down")) as any;
+      const result = await verify.resolve({ attestationId: TEST_ATTESTATION_ID });
+      expect(result).toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("rejects untrusted verifyUrl and falls back to VERIFY_SERVER", async () => {
+      const expected = { origin: "https://uniswap.org" };
+      global.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        json: async () => expected,
+      }) as any;
+      await verify.resolve({
+        attestationId: TEST_ATTESTATION_ID,
+        verifyUrl: "https://evil.example.com",
+      });
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${VERIFY_SERVER}/attestation/${TEST_ATTESTATION_ID}`,
+        expect.anything(),
+      );
+    });
+
+    it("uses caller-provided verifyUrl when it is in the trusted list", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        json: async () => ({ origin: "https://x.com" }),
+      }) as any;
+      await verify.resolve({
+        attestationId: TEST_ATTESTATION_ID,
+        verifyUrl: VERIFY_FALLBACK_SERVER,
+      });
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${VERIFY_FALLBACK_SERVER}/attestation/${TEST_ATTESTATION_ID}`,
+        expect.anything(),
+      );
+    });
+
+    it("skips fallback when primary is already the fallback server", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("net down")) as any;
+      const result = await verify.resolve({
+        attestationId: TEST_ATTESTATION_ID,
+        verifyUrl: VERIFY_FALLBACK_SERVER,
+      });
+      expect(result).toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${VERIFY_FALLBACK_SERVER}/attestation/${TEST_ATTESTATION_ID}`,
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -26,7 +26,6 @@ import {
   IEngineEvents,
   JsonRpcTypes,
   PendingRequestTypes,
-  Verify,
   CoreTypes,
   ProposalTypes,
   RelayerTypes,
@@ -69,6 +68,7 @@ import {
   getDeepLink,
 } from "@exodus/walletconnect-utils";
 import EventEmmiter from "events";
+import { buildVerifyContext } from "../utils/verifyContext";
 import {
   ENGINE_CONTEXT,
   ENGINE_RPC_OPTS,
@@ -1457,17 +1457,15 @@ export class Engine extends IEngine {
     await this.isValidSessionOrPairingTopic(topic);
   };
 
-  private getVerifyContext = async (_hash: string, metadata: CoreTypes.Metadata) => {
-    const context: Verify.Context = {
-      verified: {
-        verifyUrl: metadata.verifyUrl || "",
-        validation: "UNKNOWN",
-        origin: metadata.url || "",
+  private getVerifyContext = (hash: string, metadata: CoreTypes.Metadata) =>
+    buildVerifyContext(
+      {
+        resolve: (args) => this.client.core.verify.resolve(args),
+        logError: (e) => this.client.logger.error(e),
       },
-    };
-
-    return context;
-  };
+      hash,
+      metadata,
+    );
 
   private validateSessionProps = (properties: ProposalTypes.SessionProperties, type: string) => {
     Object.values(properties).forEach((property) => {

--- a/packages/sign-client/src/utils/verifyContext.ts
+++ b/packages/sign-client/src/utils/verifyContext.ts
@@ -20,8 +20,7 @@ export const buildVerifyContext = async (
     try {
       const attestation = await resolve({ attestationId });
       if (attestation) {
-        const origin =
-          typeof attestation === "string" ? attestation : (attestation as any).origin;
+        const origin = typeof attestation === "string" ? attestation : (attestation as any).origin;
         if (origin && typeof origin === "string") {
           // Registered dApps always declare metadata.url; receiving an attested
           // origin while the dApp claims nothing is mismatch by definition.

--- a/packages/sign-client/src/utils/verifyContext.ts
+++ b/packages/sign-client/src/utils/verifyContext.ts
@@ -1,0 +1,73 @@
+import { CoreTypes, Verify } from "@exodus/walletconnect-types";
+
+export interface BuildVerifyContextDeps {
+  resolve: (args: {
+    attestationId: string;
+    verifyUrl?: string;
+  }) => Promise<{ origin?: string; isScam?: boolean } | string | undefined>;
+  logError?: (err: unknown) => void;
+}
+
+export const buildVerifyContext = async (
+  { resolve, logError }: BuildVerifyContextDeps,
+  attestationId: string,
+  metadata: CoreTypes.Metadata,
+): Promise<Verify.Context> => {
+  if (!metadata?.url) {
+    const context: Verify.Context = {
+      verified: { verifyUrl: "", validation: "UNKNOWN", origin: "" },
+    };
+    try {
+      const attestation = await resolve({ attestationId });
+      if (attestation) {
+        const origin =
+          typeof attestation === "string" ? attestation : (attestation as any).origin;
+        if (origin && typeof origin === "string") {
+          // Registered dApps always declare metadata.url; receiving an attested
+          // origin while the dApp claims nothing is mismatch by definition.
+          context.verified.origin = origin;
+          context.verified.validation = "INVALID";
+        }
+        if (typeof attestation === "object" && (attestation as any).isScam) {
+          context.verified.isScam = true;
+        }
+      }
+    } catch (e) {
+      logError?.(e);
+    }
+    return context;
+  }
+
+  const context: Verify.Context = {
+    verified: {
+      verifyUrl: metadata.verifyUrl || "",
+      validation: "UNKNOWN",
+      origin: metadata.url || "",
+    },
+  };
+
+  try {
+    const attestation = await resolve({
+      attestationId,
+      verifyUrl: metadata.verifyUrl,
+    });
+    if (attestation) {
+      const origin = typeof attestation === "string" ? attestation : (attestation as any).origin;
+      if (origin && typeof origin === "string") {
+        context.verified.origin = origin;
+        let claimedOrigin = metadata.url || "";
+        try {
+          claimedOrigin = new URL(metadata.url).origin;
+        } catch {}
+        context.verified.validation = origin === claimedOrigin ? "VALID" : "INVALID";
+      }
+      if (typeof attestation === "object" && (attestation as any).isScam) {
+        context.verified.isScam = true;
+      }
+    }
+  } catch (e) {
+    logError?.(e);
+  }
+
+  return context;
+};

--- a/packages/sign-client/test/sdk/engineVerifyWiring.spec.ts
+++ b/packages/sign-client/test/sdk/engineVerifyWiring.spec.ts
@@ -1,0 +1,162 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+import { Engine } from "../../src/controllers/engine";
+
+const DAPP_ORIGIN = "https://app.uniswap.org";
+const WALLET_ORIGIN = "https://my-wallet.example.com";
+
+function createMockClient(walletUrl: string) {
+  return {
+    metadata: { name: "Test Wallet", description: "", url: walletUrl, icons: [] },
+    events: new EventEmitter(),
+    logger: {
+      error: vi.fn(),
+      trace: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+    core: {
+      verify: { resolve: vi.fn() },
+      expirer: { set: vi.fn() },
+    },
+    proposal: { set: vi.fn() },
+    session: {
+      get: vi.fn(),
+    },
+    pendingRequest: { set: vi.fn() },
+  } as any;
+}
+
+function proposalPayload(id: number, proposerUrl: string) {
+  return {
+    id,
+    params: {
+      proposer: {
+        publicKey: "abc123",
+        metadata: {
+          name: "dApp",
+          description: "",
+          url: proposerUrl,
+          icons: [],
+        },
+      },
+      requiredNamespaces: {
+        eip155: {
+          methods: ["eth_sendTransaction"],
+          chains: ["eip155:1"],
+          events: ["chainChanged"],
+        },
+      },
+      relays: [{ protocol: "irn" }],
+    },
+  };
+}
+
+function sessionRequestPayload(id: number) {
+  return {
+    id,
+    params: {
+      request: { method: "personal_sign", params: ["0xdeadbeef", "0x0"] },
+      chainId: "eip155:1",
+    },
+  };
+}
+
+describe("Engine verifyContext wiring – session_proposal", () => {
+  let mockClient: ReturnType<typeof createMockClient>;
+  let engine: Engine;
+
+  beforeEach(() => {
+    mockClient = createMockClient(WALLET_ORIGIN);
+    engine = new Engine(mockClient);
+
+    (engine as any).isValidConnect = vi.fn();
+    (engine as any).setProposal = vi.fn();
+  });
+
+  it("passes proposer metadata (not wallet metadata) to buildVerifyContext — VALID when origins match", async () => {
+    mockClient.core.verify.resolve.mockResolvedValue({ origin: DAPP_ORIGIN });
+
+    const proposalReceived = new Promise<any>((resolve) => {
+      mockClient.events.once("session_proposal", resolve);
+    });
+
+    const payload = proposalPayload(1, DAPP_ORIGIN);
+    await (engine as any).onSessionProposeRequest("pairing-topic", payload);
+
+    const event = await proposalReceived;
+    expect(event.verifyContext.verified.validation).toBe("VALID");
+    expect(event.verifyContext.verified.origin).toBe(DAPP_ORIGIN);
+  });
+
+  it("detects wrong-metadata bug: attestation matches WALLET url yields INVALID for proposer", async () => {
+    mockClient.core.verify.resolve.mockResolvedValue({ origin: WALLET_ORIGIN });
+
+    const proposalReceived = new Promise<any>((resolve) => {
+      mockClient.events.once("session_proposal", resolve);
+    });
+
+    const payload = proposalPayload(2, DAPP_ORIGIN);
+    await (engine as any).onSessionProposeRequest("pairing-topic", payload);
+
+    const event = await proposalReceived;
+    expect(event.verifyContext.verified.validation).toBe("INVALID");
+    expect(event.verifyContext.verified.origin).toBe(WALLET_ORIGIN);
+  });
+});
+
+describe("Engine verifyContext wiring – session_request", () => {
+  let mockClient: ReturnType<typeof createMockClient>;
+  let engine: Engine;
+
+  const peerMetadataUrl = "https://dapp-peer.example.com";
+
+  beforeEach(() => {
+    mockClient = createMockClient(WALLET_ORIGIN);
+    engine = new Engine(mockClient);
+
+    (engine as any).isValidRequest = vi.fn();
+    (engine as any).setPendingSessionRequest = vi.fn();
+
+    mockClient.session.get.mockReturnValue({
+      peer: {
+        metadata: {
+          name: "Peer dApp",
+          description: "",
+          url: peerMetadataUrl,
+          icons: [],
+        },
+      },
+    });
+  });
+
+  it("passes session.peer.metadata (not wallet metadata) to buildVerifyContext", async () => {
+    mockClient.core.verify.resolve.mockResolvedValue({ origin: peerMetadataUrl });
+
+    const requestReceived = new Promise<any>((resolve) => {
+      mockClient.events.once("session_request", resolve);
+    });
+
+    const payload = sessionRequestPayload(100);
+    await (engine as any).onSessionRequest("session-topic", payload);
+
+    const event = await requestReceived;
+    expect(event.verifyContext.verified.validation).toBe("VALID");
+    expect(event.verifyContext.verified.origin).toBe(peerMetadataUrl);
+  });
+
+  it("yields INVALID when attestation matches wallet url instead of peer metadata", async () => {
+    mockClient.core.verify.resolve.mockResolvedValue({ origin: WALLET_ORIGIN });
+
+    const requestReceived = new Promise<any>((resolve) => {
+      mockClient.events.once("session_request", resolve);
+    });
+
+    const payload = sessionRequestPayload(101);
+    await (engine as any).onSessionRequest("session-topic", payload);
+
+    const event = await requestReceived;
+    expect(event.verifyContext.verified.validation).toBe("INVALID");
+    expect(event.verifyContext.verified.origin).toBe(WALLET_ORIGIN);
+  });
+});

--- a/packages/sign-client/test/sdk/verifyContext.spec.ts
+++ b/packages/sign-client/test/sdk/verifyContext.spec.ts
@@ -1,0 +1,192 @@
+import { expect, describe, it, vi } from "vitest";
+import { buildVerifyContext } from "../../src/utils/verifyContext";
+
+const noopLog = (_err: unknown) => {
+  return;
+};
+
+describe("buildVerifyContext", () => {
+  it("returns UNKNOWN when resolver returns undefined", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve(undefined), logError: noopLog },
+      "hash",
+      { name: "x", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+    expect(ctx.verified.origin).toBe("https://app.uniswap.org");
+  });
+
+  it("returns UNKNOWN when resolver throws", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.reject(new Error("network")),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "x", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+  });
+
+  it("returns VALID when attested origin matches dApp metadata.url", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://app.uniswap.org" }),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "Uniswap", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("VALID");
+    expect(ctx.verified.origin).toBe("https://app.uniswap.org");
+  });
+
+  it("returns INVALID when attested origin differs from claimed metadata.url (spoofing)", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://attacker.com" }),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "Uniswap", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("INVALID");
+    expect(ctx.verified.origin).toBe("https://attacker.com");
+  });
+
+  it("propagates isScam=true", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://attacker.com", isScam: true }),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "Uniswap", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.isScam).toBe(true);
+  });
+
+  it("does not set isScam when attestation lacks the flag", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://app.uniswap.org" }),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "Uniswap", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.isScam).toBeUndefined();
+  });
+
+  it("supports string-shaped attestation response (legacy)", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve("https://app.uniswap.org"), logError: noopLog },
+      "hash",
+      { name: "Uniswap", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("VALID");
+    expect(ctx.verified.origin).toBe("https://app.uniswap.org");
+  });
+
+  it("forwards verifyUrl from metadata to resolver", async () => {
+    const spy = vi.fn().mockResolvedValue(undefined);
+    await buildVerifyContext({ resolve: spy, logError: noopLog }, "h", {
+      name: "x",
+      description: "",
+      url: "https://x.com",
+      icons: [],
+      verifyUrl: "https://verify.example.com",
+    });
+    expect(spy).toHaveBeenCalledWith({
+      attestationId: "h",
+      verifyUrl: "https://verify.example.com",
+    });
+  });
+
+  it("returns UNKNOWN with empty origin when metadata is undefined", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve(undefined), logError: noopLog },
+      "hash",
+      undefined as any,
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+    expect(ctx.verified.origin).toBe("");
+    expect(ctx.verified.verifyUrl).toBe("");
+  });
+
+  it("returns UNKNOWN with empty origin when metadata is null", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve(undefined), logError: noopLog },
+      "hash",
+      null as any,
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+    expect(ctx.verified.origin).toBe("");
+    expect(ctx.verified.verifyUrl).toBe("");
+  });
+
+  it("returns UNKNOWN with empty origin when metadata.url is empty string", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve(undefined), logError: noopLog },
+      "hash",
+      { name: "x", description: "", url: "", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+    expect(ctx.verified.origin).toBe("");
+  });
+
+  it("propagates isScam even when metadata is undefined", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://attacker.com", isScam: true }),
+        logError: noopLog,
+      },
+      "hash",
+      undefined as any,
+    );
+    expect(ctx.verified.isScam).toBe(true);
+  });
+
+  it("flags empty-url dApp as INVALID when Reown returns an attested origin", async () => {
+    // Spoof scenario: attacker omits metadata.url so the legacy null-guard
+    // skipped validation entirely. Receiving an attested origin means Reown
+    // knows the real source — surface it as INVALID.
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://evil.com" }),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "Uniswap", description: "", url: "", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("INVALID");
+    expect(ctx.verified.origin).toBe("https://evil.com");
+  });
+
+  it("flags empty-url dApp as INVALID when attestation is a bare string", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve("https://evil.com"), logError: noopLog },
+      "hash",
+      undefined as any,
+    );
+    expect(ctx.verified.validation).toBe("INVALID");
+    expect(ctx.verified.origin).toBe("https://evil.com");
+  });
+
+  it("defaults context.verifyUrl/origin from metadata when no attestation", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve(undefined), logError: noopLog },
+      "h",
+      {
+        name: "x",
+        description: "",
+        url: "https://x.com",
+        icons: [],
+        verifyUrl: "https://verify.example.com",
+      },
+    );
+    expect(ctx.verified.verifyUrl).toBe("https://verify.example.com");
+    expect(ctx.verified.origin).toBe("https://x.com");
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+  });
+});

--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -35,13 +35,13 @@ function _hkdf32(key: Uint8Array) {
     throw new Error("key must be of length 32");
   }
   const zeroes = new Uint8Array(32);
-  const prk = hmacSync('sha256', zeroes, key, 'uint8');
+  const prk = hmacSync("sha256", zeroes, key, "uint8");
 
   // Since the derived key will be of length 32, we only need to do one HMAC.
   // There's no need for writing a loop that repeadly calls HMAC.
   const one = new Uint8Array([1]);
 
-  return hmacSync('sha256', prk, one, 'uint8');
+  return hmacSync("sha256", prk, one, "uint8");
 }
 
 export function uint8array2hex(arr: Uint8Array): string {
@@ -74,7 +74,7 @@ export function deriveSymKey(privateKeyA: string, publicKeyB: string): string {
 }
 
 export function hashKey(key: string): string {
-  return hashSync('sha256', hex2uint8array(key), 'hex');
+  return hashSync("sha256", hex2uint8array(key), "hex");
 }
 
 function utf8string2uint8array(str: string): Uint8Array {
@@ -82,7 +82,7 @@ function utf8string2uint8array(str: string): Uint8Array {
 }
 
 export function hashMessage(message: string): string {
-  return hashSync('sha256', message, 'hex');
+  return hashSync("sha256", message, "hex");
 }
 
 export function encodeTypeByte(type: number): Uint8Array {
@@ -114,7 +114,7 @@ export async function encrypt(params: CryptoTypes.EncryptParams): Promise<string
     data: utf8string2uint8array(params.message),
     key: hex2uint8array(params.symKey),
     nonce: iv,
-  })
+  });
   return serialize({ type, sealed, iv, senderPublicKey });
 }
 
@@ -124,7 +124,7 @@ export async function decrypt(params: CryptoTypes.DecryptParams): Promise<string
     data: sealed,
     key: hex2uint8array(params.symKey),
     nonce: iv,
-  })
+  });
   if (message === null) throw new Error("Failed to decrypt");
   return Buffer.from(message).toString("utf8");
 }


### PR DESCRIPTION
## Summary

Restore `Verify.resolve` and `getVerifyContext` so consumers can read `verifyContext` from session proposals and requests.

These had been stubbed in 2023 (commit `ff413be`) because the upstream implementation relied on browser-only iframe attestation. The wallet-side resolution path is a plain `fetch` and is RN-compatible; this PR re-enables it.

## Changes

- `packages/core/src/constants/verify.ts` - restore `VERIFY_SERVER`, `VERIFY_FALLBACK_SERVER`, `TRUSTED_VERIFY_URLS`, `VERIFY_FETCH_TIMEOUT_MS`
- `packages/core/src/controllers/verify.ts` - `fetch`-based `resolve` with 2s `AbortController` timeout and fallback host
- `packages/sign-client/src/controllers/engine.ts` - `getVerifyContext` calls `core.verify.resolve` to populate `origin / validation / isScam`
- `packages/core/test/verify.spec.ts` - 9 unit tests

## Failure modes

All non-200 / fetch errors are caught and degrade to `validation: "UNKNOWN"`, so callers see fail-soft behaviour. Integration tests under `packages/sign-client/test/sdk/integration/` issue real fetches per session_proposal / request; failures continue to degrade to `UNKNOWN`.

## Release

`lerna.json` is fixed-mode (`version: "2.11.0"`) but per-package suffixes diverge (`core 2.11.0-exodus.4`, `sign-client 2.11.0-exodus.2`, `web3wallet 1.10.0-exodus.3`). Do not run `lerna version`. Bump per-package:

```bash
cd packages/core && npm version 2.11.0-exodus.5 --no-git-tag-version
cd ../sign-client && npm version 2.11.0-exodus.3 --no-git-tag-version
```

Then `npm publish` per package.

## Companion PR

- `ExodusForks/auth-client-js#2` - same activation in auth-client engine
