### PR TITLE
chore(release): core 2.11.0-exodus.5, sign-client 2.11.0-exodus.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4215,6 +4215,29 @@
         "node": ">=16"
       }
     },
+    "node_modules/@exodus/walletconnect-auth-client/node_modules/@exodus/walletconnect-core": {
+      "version": "2.7.6-exodus.2",
+      "resolved": "https://registry.npmjs.org/@exodus/walletconnect-core/-/walletconnect-core-2.7.6-exodus.2.tgz",
+      "integrity": "sha512-vMqND3yEVhRks37iB3eSCQdaX0U2JCXJyWUkmuxSxq00nwxFFr8kBC040fyFMtYfhZJ6V/WiYmOrLoKHYAyGBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@exodus/walletconnect-heartbeat": "^1.2.1-exodus.0",
+        "@exodus/walletconnect-jsonrpc-provider": "^1.0.13-exodus.1",
+        "@exodus/walletconnect-jsonrpc-types": "^1.0.3-exodus.0",
+        "@exodus/walletconnect-jsonrpc-utils": "^1.0.8-exodus.0",
+        "@exodus/walletconnect-jsonrpc-ws-connection": "^1.0.11-exodus.1",
+        "@exodus/walletconnect-keyvaluestorage": "^1.0.2-exodus.0",
+        "@exodus/walletconnect-logger": "^2.0.1-exodus.1",
+        "@exodus/walletconnect-relay-api": "^1.0.9-exodus.0",
+        "@exodus/walletconnect-relay-auth": "^1.0.4-exodus.0",
+        "@exodus/walletconnect-safe-json": "^1.0.2-exodus.0",
+        "@exodus/walletconnect-time": "^1.0.2-exodus.0",
+        "@exodus/walletconnect-types": "^2.7.6-exodus.0",
+        "@exodus/walletconnect-utils": "^2.7.6-exodus.0",
+        "events": "^3.3.0",
+        "lodash.isequal": "4.5.0"
+      }
+    },
     "node_modules/@exodus/walletconnect-auth-client/node_modules/@exodus/walletconnect-types": {
       "version": "2.7.6-exodus.1",
       "resolved": "https://registry.npmjs.org/@exodus/walletconnect-types/-/walletconnect-types-2.7.6-exodus.1.tgz",
@@ -29499,7 +29522,7 @@
     },
     "packages/core": {
       "name": "@exodus/walletconnect-core",
-      "version": "2.11.0-exodus.4",
+      "version": "2.11.0-exodus.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@exodus/fetch": "^1.3.0",
@@ -29564,7 +29587,7 @@
     },
     "packages/sign-client": {
       "name": "@exodus/walletconnect-sign-client",
-      "version": "2.11.0-exodus.2",
+      "version": "2.11.0-exodus.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@exodus/walletconnect-core": "^2.11.0-exodus.3",
@@ -29600,7 +29623,7 @@
     },
     "packages/utils": {
       "name": "@exodus/walletconnect-utils",
-      "version": "2.11.0-exodus.3",
+      "version": "2.11.0-exodus.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@exodus/crypto": "^1.0.0-rc.26",
@@ -32667,6 +32690,28 @@
         "sha.js": "^2.4.11"
       },
       "dependencies": {
+        "@exodus/walletconnect-core": {
+          "version": "2.7.6-exodus.2",
+          "resolved": "https://registry.npmjs.org/@exodus/walletconnect-core/-/walletconnect-core-2.7.6-exodus.2.tgz",
+          "integrity": "sha512-vMqND3yEVhRks37iB3eSCQdaX0U2JCXJyWUkmuxSxq00nwxFFr8kBC040fyFMtYfhZJ6V/WiYmOrLoKHYAyGBw==",
+          "requires": {
+            "@exodus/walletconnect-heartbeat": "^1.2.1-exodus.0",
+            "@exodus/walletconnect-jsonrpc-provider": "^1.0.13-exodus.1",
+            "@exodus/walletconnect-jsonrpc-types": "^1.0.3-exodus.0",
+            "@exodus/walletconnect-jsonrpc-utils": "^1.0.8-exodus.0",
+            "@exodus/walletconnect-jsonrpc-ws-connection": "^1.0.11-exodus.1",
+            "@exodus/walletconnect-keyvaluestorage": "^1.0.2-exodus.0",
+            "@exodus/walletconnect-logger": "^2.0.1-exodus.1",
+            "@exodus/walletconnect-relay-api": "^1.0.9-exodus.0",
+            "@exodus/walletconnect-relay-auth": "^1.0.4-exodus.0",
+            "@exodus/walletconnect-safe-json": "^1.0.2-exodus.0",
+            "@exodus/walletconnect-time": "^1.0.2-exodus.0",
+            "@exodus/walletconnect-types": "^2.7.6-exodus.0",
+            "@exodus/walletconnect-utils": "^2.7.6-exodus.0",
+            "events": "^3.3.0",
+            "lodash.isequal": "4.5.0"
+          }
+        },
         "@exodus/walletconnect-types": {
           "version": "2.7.6-exodus.1",
           "resolved": "https://registry.npmjs.org/@exodus/walletconnect-types/-/walletconnect-types-2.7.6-exodus.1.tgz",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@exodus/walletconnect-core",
   "description": "Core for WalletConnect Protocol",
-  "version": "2.11.0-exodus.4",
+  "version": "2.11.0-exodus.5",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@exodus/walletconnect-sign-client",
   "description": "Sign Client for WalletConnect Protocol",
-  "version": "2.11.0-exodus.2",
+  "version": "2.11.0-exodus.3",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bumps for Verify API enablement (PR #24).

- @exodus/walletconnect-core: 2.11.0-exodus.4 → 2.11.0-exodus.5
- @exodus/walletconnect-sign-client: 2.11.0-exodus.2 → 2.11.0-exodus.3